### PR TITLE
Handle validation errors for invoice total requests

### DIFF
--- a/backend/src/main/java/com/verifyme/controller/GlobalErrorMapper.java
+++ b/backend/src/main/java/com/verifyme/controller/GlobalErrorMapper.java
@@ -1,11 +1,17 @@
 package com.verifyme.controller;
 
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.ElementKind;
+import jakarta.validation.Path;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
+
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
 
 @Provider
 public class GlobalErrorMapper implements ExceptionMapper<Throwable> {
@@ -16,8 +22,47 @@ public class GlobalErrorMapper implements ExceptionMapper<Throwable> {
 
   @Override
   public Response toResponse(Throwable ex) {
+    if (ex instanceof ConstraintViolationException cve) {
+      String message = cve.getConstraintViolations().stream()
+          .map(v -> formatViolation(v.getPropertyPath(), v.getMessage()))
+          .sorted()
+          .collect(Collectors.joining("; "));
+      return text(400, message);
+    }
     if (ex instanceof BadRequestException) return text(400, ex.getMessage());
     if (ex instanceof NotFoundException)  return text(404, ex.getMessage());
     return text(500, "internal server error");
+  }
+
+  private String formatViolation(Path path, String message) {
+    if (path == null) return message;
+
+    StringJoiner joiner = new StringJoiner(".");
+    for (Path.Node node : path) {
+      ElementKind kind = node.getKind();
+      if (kind == ElementKind.METHOD
+          || kind == ElementKind.PARAMETER
+          || kind == ElementKind.CROSS_PARAMETER
+          || kind == ElementKind.RETURN_VALUE
+          || kind == ElementKind.CONSTRUCTOR
+          || kind == ElementKind.BEAN) {
+        continue;
+      }
+
+      String name = node.getName();
+      if (name == null || name.isBlank()) continue;
+
+      if (node.getIndex() != null) {
+        joiner.add(name + "[" + node.getIndex() + "]");
+      } else if (node.getKey() != null) {
+        joiner.add(name + "[" + node.getKey() + "]");
+      } else {
+        joiner.add(name);
+      }
+    }
+
+    String pathText = joiner.toString();
+    if (pathText.isBlank()) return message;
+    return pathText + " " + message;
   }
 }

--- a/backend/src/test/java/com/verifyme/controller/InvoiceControllerValidationTest.java
+++ b/backend/src/test/java/com/verifyme/controller/InvoiceControllerValidationTest.java
@@ -1,0 +1,27 @@
+package com.verifyme.controller;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+
+import jakarta.ws.rs.core.MediaType;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
+
+@QuarkusTest
+class InvoiceControllerValidationTest {
+
+  @Test
+  void total_missingInvoice_returnsBadRequestWithPlainTextError() {
+    RestAssured.given()
+        .contentType(MediaType.APPLICATION_JSON)
+        .body("{}")
+        .when()
+        .post("/invoice/total")
+        .then()
+        .statusCode(400)
+        .header("Content-Type", startsWith(MediaType.TEXT_PLAIN))
+        .body(equalTo("Error: invoice must not be null"));
+  }
+}


### PR DESCRIPTION
## Summary
- format ConstraintViolationException messages into consistent plain-text responses
- ensure validation errors on /invoice/total return HTTP 400 with an integration test

## Testing
- mvn -f backend/pom.xml test *(fails: unable to download Quarkus dependencies, HTTP 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e104e070d08327b930fb8fd402d7f7